### PR TITLE
fix(install): Install dependencies script work with subsequent installs

### DIFF
--- a/scripts/install-dependencies.js
+++ b/scripts/install-dependencies.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var spawn = require('child_process').spawnSync;
+var path = require('path');
 
 function getSpawn(command, args, options) {
   if (!/^win/.test(process.platform)) { // linux
@@ -20,5 +21,7 @@ var abiVersion = process.versions.modules;
 var os = process.platform;
 var teradataPrebuiltFastcallVersion = '0.2.6';
 var teradataNativelibVersion = '1.0.0-beta.1';
+var app_root_dir = path.resolve(__dirname).split('node_modules')[0];
 
-getSpawn('npm', ['install', '--no-save', '@teradataprebuilt/fastcall-' + os + '-' + platform + '-v' + abiVersion + '@' + teradataPrebuiltFastcallVersion, '@teradataprebuilt/nativelib-' + os + '@' + teradataNativelibVersion]);
+process.chdir(app_root_dir);
+getSpawn('npm', ['install', '--save', '@teradataprebuilt/fastcall-' + os + '-' + platform + '-v' + abiVersion + '@' + teradataPrebuiltFastcallVersion, '@teradataprebuilt/nativelib-' + os + '@' + teradataNativelibVersion]);

--- a/src/teradata-connection.ts
+++ b/src/teradata-connection.ts
@@ -72,11 +72,11 @@ export class TeradataConnection {
     // Setup libpath for fastcall.library
     let libpath: string = '';
     if (process.platform === 'win32') {
-      libpath = __dirname + '/node_modules/@teradataprebuilt/nativelib-win32/teradatasql.dll';
+      libpath = 'node_modules/@teradataprebuilt/nativelib-win32/teradatasql.dll';
     } else if (process.platform === 'darwin') {
-      libpath = __dirname + '/node_modules/@teradataprebuilt/nativelib-darwin/teradatasql.dylib';
+      libpath = 'node_modules/@teradataprebuilt/nativelib-darwin/teradatasql.dylib';
     } else if (process.platform === 'freebsd' || process.platform === 'linux') {
-      libpath = __dirname + '/node_modules/@teradataprebuilt/nativelib-linux/teradatasql.so';
+      libpath = 'node_modules/@teradataprebuilt/nativelib-linux/teradatasql.so';
     }
 
     // Load native library with libpath and options


### PR DESCRIPTION
## Description
Install dependencies script work with subsequent installs
closes #2 

### What's included?

- modified:   scripts/install-dependencies.js
- modified:   src/teradata-connection.ts

