### PR TITLE
GitHub Actions integration tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.github/workflows/ci-integration-tests.yml
+++ b/.github/workflows/ci-integration-tests.yml
@@ -1,0 +1,117 @@
+name: CI Integration Tests
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download Vantage Express
+        shell: bash
+        run: |
+          brew install hudochenkov/sshpass/sshpass
+          echo "my IP address is: " $(ipconfig getifaddr en0)
+          mkdir /tmp/downloads
+          cd /tmp/downloads
+          curl -L 'https://downloads.teradata.com/download/cdn/database/teradata-express/VantageExpress17.10_Sles12_202108300444.7z' \
+            -H 'Cookie: $TD_DOWNLOADS_MAGIC_COOKIE' --compressed -o ve.7z
+        env:
+          TD_DOWNLOADS_MAGIC_COOKIE: ${{ secrets.TD_DOWNLOADS_MAGIC_COOKIE }}
+
+      - name: Unzip Vantage Express
+        shell: bash
+        run: |            
+          cd /tmp/downloads
+          7z x ve.7z
+
+      - name: Install Vantage Express
+        shell: bash
+        run: |          
+          export VM_IMAGE_DIR="/tmp/downloads/VantageExpress17.10_Sles12"
+          DEFAULT_VM_NAME="vantage-express-17.10"
+          VM_NAME="${VM_NAME:-$DEFAULT_VM_NAME}"
+          vboxmanage createvm --name "$VM_NAME" --register --ostype openSUSE_64
+          vboxmanage modifyvm "$VM_NAME" --ioapic on --memory 6000 --vram 128 --nic1 nat --cpus 3
+          vboxmanage storagectl "$VM_NAME" --name "SATA Controller" --add sata --controller IntelAhci
+          vboxmanage storageattach "$VM_NAME" --storagectl "SATA Controller" --port 0 --device 0 --type hdd --medium  "$(find $VM_IMAGE_DIR -name '*disk1*')"
+          vboxmanage storageattach "$VM_NAME" --storagectl "SATA Controller" --port 1 --device 0 --type hdd --medium  "$(find $VM_IMAGE_DIR -name '*disk2*')"
+          vboxmanage storageattach "$VM_NAME" --storagectl "SATA Controller" --port 2 --device 0 --type hdd --medium  "$(find $VM_IMAGE_DIR -name '*disk3*')"
+          vboxmanage modifyvm "$VM_NAME" --natpf1 "tdssh,tcp,,4422,,22"
+          vboxmanage modifyvm "$VM_NAME" --natpf1 "tddb,tcp,,1025,,1025"
+          vboxmanage startvm "$VM_NAME" --type headless
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          cache: npm        
+      - run: npm install
+
+      - name: Install TTU
+        shell: bash
+        run: |   
+          curl -L 'https://downloads.teradata.com/download/cdn/tools/ttu/TeradataToolsAndUtilitiesBase__macosx_x86_64.17.10.11.00.tar.gz' \
+            -H 'Cookie: $TD_DOWNLOADS_MAGIC_COOKIE' --compressed -o ttu.tar.gz
+          tar -xzf ttu.tar.gz
+          
+          installer -pkg ./TeradataToolsAndUtilitiesBase/*.pkg -target CurrentUserHomeDirectory
+        env:
+          TD_DOWNLOADS_MAGIC_COOKIE: ${{ secrets.TD_DOWNLOADS_MAGIC_COOKIE }}          
+
+      - name: Verify Vantage Express is running
+        shell: bash
+        run: |   
+          # add bteq to path
+          export PATH=$PATH:"/Users/runner/Library/Application Support/teradata/client/17.10/bin/"
+
+          # prepare bteq test script
+          cat << EOF > /tmp/test.bteq
+          .SET EXITONDELAY ON MAXREQTIME 20
+          .logon 127.0.0.1/dbc,dbc
+          select current_time;
+          .logoff
+          EOF
+
+          n=1
+          until [ "$n" -ge 10 ]
+          do
+            echo "Trying to connect to Vantage Express. Attempt $n. This might take a minute."
+            bteq < /tmp/test.bteq && break
+            n=$((n+1))
+            sshpass -p root ssh -o StrictHostKeyChecking=no -p 4422 root@localhost 'tail -200 /var/log/messages' || true
+            echo "Waiting 10 seconds before the next attempt."
+            sleep 10
+          done
+
+      - name: Prepare Vantage Express
+        shell: bash
+        run: |
+          export PATH=$PATH:"/Users/runner/Library/Application Support/teradata/client/17.10/bin/"
+          cat << EOF > /tmp/install.bteq
+          .SET EXITONDELAY ON MAXREQTIME 20
+          .logon 127.0.0.1/dbc,dbc
+          CREATE USER TD01
+            AS  
+            PERMANENT = 1000000000 BYTES 
+            PASSWORD = TD01
+            TEMPORARY = 1000000000 BYTES 
+            SPOOL = 1000000000 BYTES;
+          
+          GRANT CREATE PROCEDURE, EXECUTE PROCEDURE, DROP PROCEDURE, 
+          CREATE EXTERNAL PROCEDURE, CREATE FUNCTION, DROP FUNCTION
+          ON TD01 
+          TO TD01;
+
+          GRANT EXECUTE PROCEDURE ON SQLJ.INSTALL_JAR TO td01;
+          GRANT EXECUTE PROCEDURE ON SQLJ.REPLACE_JAR TO td01;
+          GRANT EXECUTE PROCEDURE ON SQLJ.REMOVE_JAR TO td01;
+          .logoff
+          EOF
+          bteq < /tmp/install.bteq
+      - name: Run tests on Mac
+        run: npm run test
+      - uses: actions/upload-artifact@v2
+        if: ${{ failure() ||  cancelled() }}
+        with:
+          name: virtualbox-logs
+          path: /Users/runner/VirtualBox*

--- a/.github/workflows/ci-integration-tests.yml
+++ b/.github/workflows/ci-integration-tests.yml
@@ -21,13 +21,13 @@ jobs:
 
       - name: Unzip Vantage Express
         shell: bash
-        run: |            
+        run: |
           cd /tmp/downloads
           7z x ve.7z
 
       - name: Install Vantage Express
         shell: bash
-        run: |          
+        run: |
           export VM_IMAGE_DIR="/tmp/downloads/VantageExpress17.10_Sles12"
           DEFAULT_VM_NAME="vantage-express-17.10"
           VM_NAME="${VM_NAME:-$DEFAULT_VM_NAME}"
@@ -44,23 +44,23 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 12
-          cache: npm        
+          cache: npm
       - run: npm install
 
       - name: Install TTU
         shell: bash
-        run: |   
+        run: |
           curl -L 'https://downloads.teradata.com/download/cdn/tools/ttu/TeradataToolsAndUtilitiesBase__macosx_x86_64.17.10.11.00.tar.gz' \
             -H 'Cookie: $TD_DOWNLOADS_MAGIC_COOKIE' --compressed -o ttu.tar.gz
           tar -xzf ttu.tar.gz
-          
+
           installer -pkg ./TeradataToolsAndUtilitiesBase/*.pkg -target CurrentUserHomeDirectory
         env:
-          TD_DOWNLOADS_MAGIC_COOKIE: ${{ secrets.TD_DOWNLOADS_MAGIC_COOKIE }}          
+          TD_DOWNLOADS_MAGIC_COOKIE: ${{ secrets.TD_DOWNLOADS_MAGIC_COOKIE }}
 
       - name: Verify Vantage Express is running
         shell: bash
-        run: |   
+        run: |
           # add bteq to path
           export PATH=$PATH:"/Users/runner/Library/Application Support/teradata/client/17.10/bin/"
 
@@ -91,15 +91,15 @@ jobs:
           .SET EXITONDELAY ON MAXREQTIME 20
           .logon 127.0.0.1/dbc,dbc
           CREATE USER TD01
-            AS  
-            PERMANENT = 1000000000 BYTES 
+            AS
+            PERMANENT = 1000000000 BYTES
             PASSWORD = TD01
-            TEMPORARY = 1000000000 BYTES 
+            TEMPORARY = 1000000000 BYTES
             SPOOL = 1000000000 BYTES;
-          
-          GRANT CREATE PROCEDURE, EXECUTE PROCEDURE, DROP PROCEDURE, 
+
+          GRANT CREATE PROCEDURE, EXECUTE PROCEDURE, DROP PROCEDURE,
           CREATE EXTERNAL PROCEDURE, CREATE FUNCTION, DROP FUNCTION
-          ON TD01 
+          ON TD01
           TO TD01;
 
           GRANT EXECUTE PROCEDURE ON SQLJ.INSTALL_JAR TO td01;

--- a/docs/RUNNINGTESTS.md
+++ b/docs/RUNNINGTESTS.md
@@ -19,6 +19,13 @@
     CREATE EXTERNAL PROCEDURE, CREATE FUNCTION, DROP FUNCTION
     ON TD01
     TO TD01;
+
+    -- if there is java installed on the client system
+    -- the test suite will attempt to test Java procedures
+    -- the following grants are required for the tests
+    GRANT EXECUTE PROCEDURE ON SQLJ.INSTALL_JAR TO td01;
+    GRANT EXECUTE PROCEDURE ON SQLJ.REPLACE_JAR TO td01;
+    GRANT EXECUTE PROCEDURE ON SQLJ.REMOVE_JAR TO td01;    
     ```
 1. Edit `test/configurations.ts` and modify the `'{ "host": "<hostname>", "user": "<username>", "password": "<password>" }'` with correct connection parameters.
 1. Run the Node.js Javascript test files:

--- a/test/configurations.ts
+++ b/test/configurations.ts
@@ -1,10 +1,10 @@
 import { ITDConnParams } from '../src/teradata-connection';
 
 export const connParams: ITDConnParams = {
-  host: '<host>',
-  log: '1',
-  password: '<password>',
-  user: '<username>',
+  host: '127.0.0.1',
+  log: '0',
+  password: 'TD01',
+  user: 'TD01',
 };
 
 export const badConnParams: ITDConnParams = {


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that runs `npm run test`. With this workflow, we are able to quickly validate contributions from the community. Since the tests need to connect to a Vantage database, the workflow sets up a temporary Vantage Express database on the GitHub Actions runner.

For now, the workflow doesn't trigger automatically. It can be only started manually from the  Actions tab.

Currently, the tests run on MacOS only. This is due to a well known limitation of GitHub Actions: https://github.com/actions/virtual-environments/issues/183 . I've some ideas how to bypass the limitation. If this works, I'll submit another PR.

The installation requires entering TD_DOWNLOADS_MAGIC_COOKIE secret. The secret is necessary to download Vantage Express from downloads.teradata.com during workflow execution. I'll share the secret in a private channel.

Here is what a sample run looks like:
![image](https://user-images.githubusercontent.com/6579240/142297658-faf3be83-064f-46d6-8b07-c3b3c3aa2177.png)


The PR also adds config for https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig extension that formats code, removes unnecessary whitespaces etc.