### PR TITLE
Add test for COP discovery

### DIFF
--- a/.github/workflows/ci-integration-tests.yml
+++ b/.github/workflows/ci-integration-tests.yml
@@ -1,6 +1,11 @@
 name: CI Integration Tests
 on:
   workflow_dispatch:
+    inputs:
+      runCOPTest:
+        description: 'Run COP test'
+        required: false
+        default: 'false'
 
 jobs:
   ciIntegrationTests:
@@ -111,6 +116,7 @@ jobs:
       - name: Run tests on Mac
         run: npm run test
       - name: Run tests for COP discovery
+        if: ${{ github.event.inputs && (github.event.inputs.runCOPTest == 'true') }}
         run: |
           brew install podman
           podman machine init

--- a/.github/workflows/ci-integration-tests.yml
+++ b/.github/workflows/ci-integration-tests.yml
@@ -112,6 +112,10 @@ jobs:
         run: npm run test
       - name: Run tests for COP discovery
         run: |
+          brew install podman
+          podman machine init
+          podman machine start
+
           IP=$(ipconfig getifaddr en0)
           cat << EOF > Dockerfile
           FROM node:12
@@ -126,8 +130,8 @@ jobs:
           CMD ["npm", "run", "test-cop"]
           EOF
 
-          docker build . -t test
-          docker run --add-host myhostcop1:$IP--add-host myhostcop2:$IP --add-host myhostcop3:$IP test
+          podman build . -t test
+          podman run --add-host myhostcop1:$IP--add-host myhostcop2:$IP --add-host myhostcop3:$IP test
 
       - uses: actions/upload-artifact@v2
         if: ${{ failure() ||  cancelled() }}

--- a/.github/workflows/ci-integration-tests.yml
+++ b/.github/workflows/ci-integration-tests.yml
@@ -110,6 +110,11 @@ jobs:
           bteq < /tmp/install.bteq
       - name: Run tests on Mac
         run: npm run test
+      - name: Run tests for COP discovery
+        run: |
+          sudo echo "127.0.0.1       myhostcop1 myhostcop2 myhostcop3" >> /etc/hosts
+          sed -i 's/127.0.0.1/myhost/g' ./test/configurations.ts
+          npm run test
       - uses: actions/upload-artifact@v2
         if: ${{ failure() ||  cancelled() }}
         with:

--- a/.github/workflows/ci-integration-tests.yml
+++ b/.github/workflows/ci-integration-tests.yml
@@ -112,9 +112,23 @@ jobs:
         run: npm run test
       - name: Run tests for COP discovery
         run: |
-          sudo echo "127.0.0.1       myhostcop1 myhostcop2 myhostcop3" >> /etc/hosts
-          sed -i 's/127.0.0.1/myhost/g' ./test/configurations.ts
-          npm run test
+          IP=$(ipconfig getifaddr en0)
+          cat << EOF > Dockerfile
+          FROM node:12
+
+          WORKDIR /usr/src/app
+          COPY package.json .
+          COPY ./src ./src
+          COPY ./test ./test
+          COPY tsconfig.json .
+          RUN npm install
+          RUN sed -i 's/127.0.0.1/myhost/g' ./test/configurations.ts
+          CMD ["npm", "run", "test-cop"]
+          EOF
+
+          docker build . -t test
+          docker run --add-host myhostcop1:$IP--add-host myhostcop2:$IP --add-host myhostcop3:$IP test
+
       - uses: actions/upload-artifact@v2
         if: ${{ failure() ||  cancelled() }}
         with:

--- a/.github/workflows/ci-integration-tests.yml
+++ b/.github/workflows/ci-integration-tests.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  ciIntegrationTests:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci-integration-tests.yml
+++ b/.github/workflows/ci-integration-tests.yml
@@ -131,7 +131,7 @@ jobs:
           EOF
 
           podman build . -t test
-          podman run --add-host myhostcop1:$IP--add-host myhostcop2:$IP --add-host myhostcop3:$IP test
+          podman run --add-host myhostcop1:$IP --add-host myhostcop2:$IP --add-host myhostcop3:$IP test
 
       - uses: actions/upload-artifact@v2
         if: ${{ failure() ||  cancelled() }}

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "scripts": {
     "test": "rimraf src/node_modules && npm run build && mocha --bail --timeout 500000 -r ts-node/register test/**/*.ts",
+    "test-cop": "rimraf src/node_modules && npm run build && mocha --bail --timeout 500000 -r ts-node/register test/**/*.ts -g 'Connects to Teradata Database'",
     "clean": "rimraf dist",
     "lint": "tslint ./src/**/*.ts ./test/**/*.ts ./examples/typescript/src/*.ts",
     "format": "tsfmt -r",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "scripts": {
     "test": "rimraf src/node_modules && npm run build && mocha --bail --timeout 500000 -r ts-node/register test/**/*.ts",
+    "test-cop:about": "test-cop script requires the following entry in /etc/hosts: 127.0.0.1       myhostcop1 myhostcop2 myhostcop3. It also requires that the config is modified: sed -i 's/127.0.0.1/myhost/g' ./test/configurations.ts .    # The GH Actions CI worfklow automates these steps",
     "test-cop": "rimraf src/node_modules && npm run build && mocha --bail --timeout 500000 -r ts-node/register test/**/*.ts -g 'Connects to Teradata Database'",
     "clean": "rimraf dist",
     "lint": "tslint ./src/**/*.ts ./test/**/*.ts ./examples/typescript/src/*.ts",


### PR DESCRIPTION
This PR adds a test for COP discovery to the CI integration tests. The test takes about 10 minutes to run so I added an input param that controls if the test should be executed.