### PR TITLE
test with multiple node versions

### DIFF
--- a/.github/workflows/ci-integration-tests.yml
+++ b/.github/workflows/ci-integration-tests.yml
@@ -10,6 +10,10 @@ on:
 jobs:
   ciIntegrationTests:
     runs-on: macos-10.15
+    strategy:
+      matrix:
+        node: [ '12', '17.4' ]
+    name: Node ${{ matrix.node }} integration test
     steps:
       - uses: actions/checkout@v2
       - name: Download Vantage Express
@@ -48,7 +52,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: ${{ matrix.node }}
           cache: npm
       - run: npm install
 

--- a/.github/workflows/ci-integration-tests.yml
+++ b/.github/workflows/ci-integration-tests.yml
@@ -119,7 +119,13 @@ jobs:
           bteq < /tmp/install.bteq
       - name: Run tests on Mac
         run: |
+          if [ "17" == "$NODE_VERSION" ]; then
+            echo "Setting NODE_OPTIONS for Node 17"
+            export NODE_OPTIONS=--openssl-legacy-provider
+          fi
           npm run test
+        env:
+          NODE_VERSION: ${{ matrix.node }}
       - name: Run tests for COP discovery
         if: ${{ github.event.inputs && (github.event.inputs.runCOPTest == 'true') }}
         run: |

--- a/.github/workflows/ci-integration-tests.yml
+++ b/.github/workflows/ci-integration-tests.yml
@@ -118,7 +118,11 @@ jobs:
           EOF
           bteq < /tmp/install.bteq
       - name: Run tests on Mac
-        run: npm run test
+        run: |
+          # newer node.js versions have certain crypto disabled, e.g. 'DES/CBC/noPadding/64/HmacSHA1'
+          # we need to enable so that tests can pass
+          export NODE_OPTIONS=--openssl-legacy-provider
+          npm run test
       - name: Run tests for COP discovery
         if: ${{ github.event.inputs && (github.event.inputs.runCOPTest == 'true') }}
         run: |

--- a/.github/workflows/ci-integration-tests.yml
+++ b/.github/workflows/ci-integration-tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: macos-10.15
     strategy:
       matrix:
-        node: [ '12', '17.4' ]
+        node: [ '12', '17' ]
     name: Node ${{ matrix.node }} integration test
     steps:
       - uses: actions/checkout@v2
@@ -119,9 +119,6 @@ jobs:
           bteq < /tmp/install.bteq
       - name: Run tests on Mac
         run: |
-          # newer node.js versions have certain crypto disabled, e.g. 'DES/CBC/noPadding/64/HmacSHA1'
-          # we need to enable so that tests can pass
-          export NODE_OPTIONS=--openssl-legacy-provider
           npm run test
       - name: Run tests for COP discovery
         if: ${{ github.event.inputs && (github.event.inputs.runCOPTest == 'true') }}

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ Database API Specification v2.0: https://www.python.org/dev/peps/pep-0249/
 
 ## Supported Platforms
 
+> :information_source: Node.js versions 14 and 16 are not supported due to an issue in Node.js that affects `node-ffi-napi` library that this driver depends on: https://github.com/node-ffi-napi/ref-napi/issues/54. Never versions of Node.js no longer have the issue. 
+
+
 For Node.js 8.x, 9.x, 10.x, 11.x use:
 ```
 "dependencies": {
@@ -32,13 +35,12 @@ For Node.js 8.x, 9.x, 10.x, 11.x use:
 }
 ```
 
-For Node.js 12.x:
+For Node.js 12.x, 17.x:
 ```
 "dependencies": {
   "teradata-nodejs-driver": "1.0.0-rc.5"
 }
 ```
-
 
 Operating Systems:
 
@@ -67,7 +69,7 @@ Operating Systems:
 
 The MIT License
 
-Copyright (c) 2021 by Teradata. All rights reserved. http://teradata.com
+Copyright (c) 2022 by Teradata. All rights reserved. http://teradata.com
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/SETUPRUNNING.md
+++ b/docs/SETUPRUNNING.md
@@ -1,8 +1,7 @@
 ## Setup
 
 ### NPM
-* Ensure you have **Node 12.x** (on a Mac use Homebrew and `brew install node@12.18.0`)
-* Ensure you have **npm 6.x** installed.
+* Ensure you have a supported version of Node installed (on a Mac use Homebrew and `brew install node@x.x.x` or `nvm install x.x.x`).
 * Add the dependency to your project. In the dependencies section of the package.json add:
 
 For Node.js 8.x, 9.x, 10.x, 11.x use:
@@ -14,7 +13,7 @@ For Node.js 8.x, 9.x, 10.x, 11.x use:
 ...
 ```
 
-For Node.js 12.x use:
+For Node.js 12.x, 17.x use:
 ```
 ...
 "dependencies": {


### PR DESCRIPTION
This change adds tests to validate that issues #22 and #33 have been resolved. The issues were caused by a bug in Node.js that was affecting `node-ffi-napi` : https://github.com/node-ffi-napi/ref-napi/issues/54 . Node.js 17 no longer has the issue so the driver works with 17 . 
The PR modifies README.md and expands the existing test process to version 17. The PR doesn't require a release.

Resolves #22 
Resolves #33 